### PR TITLE
Fixed issue #4 cannot write to Vesc.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,8 @@ upload_speed = 921600
 lib_deps = 
 	h2zero/NimBLE-Arduino@^1.3.7
 	arduinogetstarted/ezButton@^1.0.3
+build_flags=
+	-D MYNEWT_VAL_BLE_ACL_BUF_COUNT=24
 check_tool = clangtidy
 check_flags = 
 	 clangtidy: --checks=-*,bugprone-*,cert-*,cppcoreguidelines-*,clang-analyzer-*,performance-*,readability-*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,6 @@ void setup()
 void loop()
 {
   bleServer->loop();
-  vesc->alive();
 #ifdef THROTTLE_CONTROLLER
   throttle->loop();
 #endif // THROTTLE_CONTROLLER

--- a/src/throttle/ButtonController.cpp
+++ b/src/throttle/ButtonController.cpp
@@ -125,6 +125,10 @@ void ButtonController::updateOutput()
         // Todo: Support more operating modes than just current_rel. E.g. Duty Cycle.
         vesc->writeCurrentRel(getOutputRel());
     }
+    if(lastWritten > 0)
+    {
+        vesc->alive();
+    }
 }
 
 /**


### PR DESCRIPTION
Issue was caused by two bugs. Firstly the vesc will not accept write commands while the 'alive' command was being sent.
Solution was to move the 'alive' command to the throttle controller and only write if the throttle is > 0.
Secondly the BLE sers ACL_BUF_COUNT was too low, causing some writes to fail if a page had too many settings.
Solution was to increase the buffer size from 12 to 24 at compile time with the MYNEWT_VAL_BLE_ACL_BUF_COUNT definition. In testing this seems acceptable.